### PR TITLE
Add title field to intel uploads

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -21,6 +21,14 @@ var (
 	db *bbolt.DB
 )
 
+func sanitizeTitle(title string) string {
+	title = strings.TrimSpace(title)
+	title = strings.ReplaceAll(title, " ", "_")
+	title = strings.ReplaceAll(title, "/", "_")
+	title = strings.ReplaceAll(title, "\\", "_")
+	return title
+}
+
 func init() {
 	var err error
 	db, err = bbolt.Open("index.db", 0666, nil)
@@ -67,6 +75,7 @@ func handleIntelFileUpload(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Bad request", http.StatusBadRequest)
 		return
 	}
+	title := sanitizeTitle(r.FormValue("title"))
 	file, _, err := r.FormFile("file")
 	if err != nil {
 		http.Error(w, "Bad request", http.StatusBadRequest)
@@ -86,9 +95,9 @@ func handleIntelFileUpload(w http.ResponseWriter, r *http.Request) {
 	}
 
 	defer file.Close()
-	// Create a unique filename based on the current timestamp
+	// Create a unique filename based on the timestamp and provided title
 	timestamp := time.Now().UnixNano()
-	filename := fmt.Sprintf("%d.txt", timestamp)
+	filename := fmt.Sprintf("%d_%s.txt", timestamp, title)
 	path := filepath.Join("data", "intel", filename)
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		http.Error(w, "Server Error", http.StatusInternalServerError)
@@ -131,10 +140,11 @@ func handleIntelTextSubmit(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Bad request", http.StatusBadRequest)
 		return
 	}
+	title := sanitizeTitle(r.FormValue("title"))
 	text := r.FormValue("text")
 	println("text" + text)
 	timestamp := time.Now().UnixNano()
-	filename := fmt.Sprintf("%d.txt", timestamp)
+	filename := fmt.Sprintf("%d_%s.txt", timestamp, title)
 	path := filepath.Join("data", "intel", filename)
 
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {

--- a/views/IntelSubmitText.templ
+++ b/views/IntelSubmitText.templ
@@ -3,14 +3,17 @@ package views
 import "grapefrui.xyz/vc13/components"
 
 templ IntelSubmitText() {
-	<h1>Upload New Intel</h1>
-	<form action="/intel/submit_text" method="post" >
-		<label for="file">Paste Text</label>
-		<br/>
-		<textarea id="text" name="text" rows="20" cols="80" required></textarea>
-		<br/>
-		<button type="submit">Submit</button>
-	</form>
+        <h1>Upload New Intel</h1>
+        <form action="/intel/submit_text" method="post" >
+                <label for="title">Title:</label>
+                <input type="text" id="title" name="title" required/>
+                <br/>
+                <label for="file">Paste Text</label>
+                <br/>
+                <textarea id="text" name="text" rows="20" cols="80" required></textarea>
+                <br/>
+                <button type="submit">Submit</button>
+        </form>
 	<ul style="display: flex; list-style: none; gap:2ch; padding-inline-start: 0;">
 		@components.NavigationLink("back", "/intel")
 	</ul>

--- a/views/IntelUploadFile.templ
+++ b/views/IntelUploadFile.templ
@@ -3,13 +3,16 @@ package views
 import "grapefrui.xyz/vc13/components"
 
 templ IntelUploadFile() {
-	<h1>Upload New Intel</h1>
-	<form action="/intel/upload_file" method="post" enctype="multipart/form-data">
-		<label for="file">Select Intel File:</label>
-		<input type="file" id="file" name="file" accept=".json,.txt,.md" required/>
-		<br/>
-		<button type="submit">Upload</button>
-	</form>
+        <h1>Upload New Intel</h1>
+        <form action="/intel/upload_file" method="post" enctype="multipart/form-data">
+                <label for="title">Title:</label>
+                <input type="text" id="title" name="title" required/>
+                <br/>
+                <label for="file">Select Intel File:</label>
+                <input type="file" id="file" name="file" accept=".json,.txt,.md" required/>
+                <br/>
+                <button type="submit">Upload</button>
+        </form>
 	<ul style="display: flex; list-style: none; gap:2ch; padding-inline-start: 0;">
 		@components.NavigationLink("back", "/intel")
 	</ul>


### PR DESCRIPTION
## Summary
- capture a title when uploading intel
- include the title in stored filenames

## Testing
- `go vet ./...` *(fails: Get https://proxy.golang.org/... Forbidden)*
- `go build ./...` *(fails: Get https://proxy.golang.org/... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6850298aae64832a97a3893e41e80f80